### PR TITLE
Add HTML Data to SharpClipboard

### DIFF
--- a/SharpClipboard/Data/HTMLData.cs
+++ b/SharpClipboard/Data/HTMLData.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WK.Libraries.SharpClipboardNS.Data
+{
+    public class HtmlData
+    {
+        public string URL { get; set; }
+        public string SelectionText { get; set; }
+        public string SelectionHTML { get; set; }
+        public string FullHTML { get; set; }
+    }
+}

--- a/SharpClipboard/SharpClipboard.cs
+++ b/SharpClipboard/SharpClipboard.cs
@@ -106,7 +106,12 @@ namespace WK.Libraries.SharpClipboardNS
             /// <summary>
             /// Represents any complex objects.
             /// </summary>
-            Other = 3
+            Other = 3,
+
+            /// <summary>
+            /// Represents a HTML copied from a browser.
+            /// </summary>
+            HTML = 4
         }
 
         #endregion

--- a/SharpClipboard/SharpClipboard.xml
+++ b/SharpClipboard/SharpClipboard.xml
@@ -64,6 +64,11 @@
             Represents any complex objects.
             </summary>
         </member>
+        <member name="F:WK.Libraries.SharpClipboardNS.SharpClipboard.ContentTypes.HTML">
+            <summary>
+            Represents a HTML copied from a browser.
+            </summary>
+        </member>
         <member name="P:WK.Libraries.SharpClipboardNS.SharpClipboard.MonitorClipboard">
             <summary>
             Gets or sets a value indicating whether the clipboard


### PR DESCRIPTION
Sorry, I haven't written the tests for it... But this essentially allows you to get the URL as well as the copied text and HTML from browsers, which is rather useful.

I have tested it in Chrome 114.0.5735.199, Firefox 115.0.1 and Edge 114.0.1823.67
Works the same on all of them.